### PR TITLE
Stop replaying stale INVALID_INPUT idempotency failures

### DIFF
--- a/internal/runtime/executor.go
+++ b/internal/runtime/executor.go
@@ -182,13 +182,18 @@ func (e *Executor) Execute(ctx context.Context, opts ExecuteOptions) (Envelope, 
 			if appErr := governance.validateIdempotencyConflict(idempotency, record, canonicalOperation, input); appErr != nil {
 				return e.auditEnvelope(governance, withExecutionMetadata(e.finish(startAt, requestID, canonicalOperation, operation.Platform, false, nil, idempotency, 0, appErr, executionProfile), warnings, &policyResult), input), nil
 			}
-			if record.Status == "in_progress" {
+			if governance.shouldRestartIdempotency(record) {
+				if err := governance.restartIdempotency(idempotency, record, canonicalOperation, requestID, input); err != nil {
+					return e.auditEnvelope(governance, withExecutionMetadata(e.finish(startAt, requestID, canonicalOperation, operation.Platform, false, nil, idempotency, 0, apperr.New("IDEMPOTENCY_STORE_FAILED", err.Error()), executionProfile), warnings, &policyResult), input), nil
+				}
+			} else if record.Status == "in_progress" {
 				idempotency.Status = record.Status
 				idempotency.Persisted = true
 				idempotency.UpdatedAt = record.UpdatedAt
 				return e.auditEnvelope(governance, withExecutionMetadata(e.finish(startAt, requestID, canonicalOperation, operation.Platform, false, nil, idempotency, record.RetryCount, apperr.New("IDEMPOTENCY_IN_PROGRESS", "write request with the same idempotency key is already in progress"), executionProfile), warnings, &policyResult), input), nil
+			} else {
+				return e.auditEnvelope(governance, withExecutionMetadata(governance.buildReplayEnvelope(startAt, requestID, executionProfile, idempotency, record), warnings, &policyResult), input), nil
 			}
-			return e.auditEnvelope(governance, withExecutionMetadata(governance.buildReplayEnvelope(startAt, requestID, executionProfile, idempotency, record), warnings, &policyResult), input), nil
 		}
 	}
 

--- a/internal/runtime/executor_test.go
+++ b/internal/runtime/executor_test.go
@@ -1536,6 +1536,89 @@ func TestExecutorRejectsIdempotencyConflict(t *testing.T) {
 	}
 }
 
+func TestExecutorRestartsRejectedInvalidInputIdempotencyRecord(t *testing.T) {
+	t.Setenv("FEISHU_BOT_OPS_APP_ID", "app-id")
+	t.Setenv("FEISHU_BOT_OPS_APP_SECRET", "app-secret")
+
+	store := newTestStore(t, &config.Config{
+		Defaults: config.Defaults{
+			Platform: "feishu",
+			Account:  "feishu_bot_ops",
+		},
+		Accounts: accountsFromLegacyAccounts(map[string]legacyTestAccount{
+			"feishu_bot_ops": {
+				Platform: "feishu",
+				Subject:  "bot",
+				LegacyAuth: legacyTestAuth{
+					Type:      "client_credentials",
+					AppID:     "env:FEISHU_BOT_OPS_APP_ID",
+					AppSecret: "env:FEISHU_BOT_OPS_APP_SECRET",
+				},
+			},
+		}),
+	})
+
+	registry := adapter.NewRegistry()
+	callCount := 0
+	shouldReject := true
+	registry.Register(adapter.Definition{
+		Operation:       "feishu.demo.write",
+		Platform:        "feishu",
+		Mutating:        true,
+		DefaultTimeout:  time.Second,
+		AllowedSubjects: []string{"bot"},
+		Spec: adapter.OperationSpec{
+			Summary: "测试写操作。",
+		},
+		Handler: func(ctx context.Context, call adapter.Call) (map[string]any, *apperr.AppError) {
+			callCount++
+			if shouldReject {
+				return nil, apperr.New("INVALID_INPUT", "old validation rejected this request")
+			}
+			return map[string]any{
+				"message": call.Input["message"],
+				"id":      "demo_1",
+			}, nil
+		},
+	})
+
+	executor := NewExecutor(store, registry)
+	firstEnvelope, err := executor.ExecuteContext(context.Background(), ExecuteOptions{
+		OperationInput: "demo.write",
+		InputJSON:      `{"message":"hello"}`,
+	})
+	if err != nil {
+		t.Fatalf("first ExecuteContext returned error: %v", err)
+	}
+	if firstEnvelope.OK {
+		t.Fatal("expected first execution to fail with INVALID_INPUT")
+	}
+	if firstEnvelope.Error == nil || firstEnvelope.Error.Code != "INVALID_INPUT" {
+		t.Fatalf("unexpected first error: %+v", firstEnvelope.Error)
+	}
+	if firstEnvelope.Idempotency == nil || firstEnvelope.Idempotency.Status != "rejected" || !firstEnvelope.Idempotency.Persisted {
+		t.Fatalf("unexpected first idempotency state: %+v", firstEnvelope.Idempotency)
+	}
+
+	shouldReject = false
+	secondEnvelope, err := executor.ExecuteContext(context.Background(), ExecuteOptions{
+		OperationInput: "demo.write",
+		InputJSON:      `{"message":"hello"}`,
+	})
+	if err != nil {
+		t.Fatalf("second ExecuteContext returned error: %v", err)
+	}
+	if !secondEnvelope.OK {
+		t.Fatalf("expected second execution to rerun instead of replaying stale INVALID_INPUT, got error: %+v", secondEnvelope.Error)
+	}
+	if secondEnvelope.Idempotency == nil || secondEnvelope.Idempotency.Status != "executed" || !secondEnvelope.Idempotency.Persisted {
+		t.Fatalf("unexpected second idempotency state: %+v", secondEnvelope.Idempotency)
+	}
+	if callCount != 2 {
+		t.Fatalf("expected handler to run twice, got %d", callCount)
+	}
+}
+
 func TestExecutorRetriesRetryableReadByConfig(t *testing.T) {
 	t.Setenv("NOTION_ACCESS_TOKEN", "notion-token")
 

--- a/internal/runtime/governance.go
+++ b/internal/runtime/governance.go
@@ -229,6 +229,49 @@ func (g *runtimeGovernance) finishIdempotency(state *IdempotencyState, record *p
 	return nil
 }
 
+func (g *runtimeGovernance) shouldRestartIdempotency(record *persistedIdempotencyRecord) bool {
+	if record == nil || record.Status != "rejected" || record.Error == nil {
+		return false
+	}
+
+	// Local input-validation failures can become stale across CLI upgrades when
+	// the same auto-generated idempotency key is derived from an unchanged input.
+	// Let those requests re-execute instead of replaying the cached rejection.
+	return strings.TrimSpace(record.Error.Code) == "INVALID_INPUT"
+}
+
+func (g *runtimeGovernance) restartIdempotency(state *IdempotencyState, record *persistedIdempotencyRecord, operation string, requestID string, input map[string]any) error {
+	if state == nil || record == nil {
+		return nil
+	}
+
+	inputHash, err := calculateInputHash(operation, input)
+	if err != nil {
+		return err
+	}
+
+	now := g.now().UTC().Format(time.RFC3339)
+	record.Operation = operation
+	record.InputHash = inputHash
+	record.Status = "in_progress"
+	record.RequestID = requestID
+	record.CreatedAt = now
+	record.UpdatedAt = now
+	record.RetryCount = 0
+	record.Data = nil
+	record.Error = nil
+	record.Meta = Meta{}
+
+	if err := g.store.SaveIdempotencyRecord(record); err != nil {
+		return err
+	}
+
+	state.Status = record.Status
+	state.Persisted = true
+	state.UpdatedAt = record.UpdatedAt
+	return nil
+}
+
 func (g *runtimeGovernance) buildReplayEnvelope(startAt time.Time, requestID string, profile ExecutionProfile, state *IdempotencyState, record *persistedIdempotencyRecord) Envelope {
 	envelope := Envelope{
 		OK:        record.Error == nil,


### PR DESCRIPTION
## Summary

Prevent stale rejected idempotency records from replaying old local validation failures after upgrades.

This fixes the remaining `notion.page.update` confusion reported in issue #12 where the same `in_trash` input could keep returning a historic `INVALID_INPUT` result even after the trash-field handling had already been fixed. The root cause was runtime idempotency replay of old rejected records created by earlier builds.

## Related Issues

- Closes #12

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Test only

## Validation

- [x] `go test ./...`
- [ ] `go build ./...`
- [ ] Manual CLI verification

List key commands or checks you ran:

```bash
go test ./internal/runtime -run 'TestExecutor(RestartsRejectedInvalidInputIdempotencyRecord|ExecutesNotionPageUpdateWithInTrash|ExecutesNotionPageUpdateWithArchivedAlias|RejectsIdempotencyConflict)' -v
go test ./internal/runtime ./internal/adapter/notion
go test ./...
```

## Notes for Reviewers

This PR deliberately keeps normal replay behavior for successful and in-progress writes. It only restarts cached idempotency records when the stored result is a local `INVALID_INPUT` rejection, because those failures can become stale across CLI upgrades while reusing the same auto-generated idempotency key.

## Checklist

- [ ] I updated docs when behavior changed.
- [x] I sanitized logs, payloads, and examples.
- [x] I kept the pull request focused and reviewable.
