### PR TITLE
Fix misleading Notion data source update spec and isolate test bot usage

### DIFF
--- a/internal/adapter/notion/data_source_spec.go
+++ b/internal/adapter/notion/data_source_spec.go
@@ -82,15 +82,16 @@ func notionDataSourceUpdateSpec() adapter.OperationSpec {
 			Required: []string{"data_source_id", "body"},
 			Notes: []string{
 				"`body` is passed through to the Notion update data source API as-is.",
+				"`body.description` is not supported by Notion for data source updates; use `notion.database.update` for database descriptions.",
 			},
 			Sample: map[string]any{
 				"data_source_id": "ds_demo",
 				"body": map[string]any{
-					"description": []any{
+					"title": []any{
 						map[string]any{
 							"type": "text",
 							"text": map[string]any{
-								"content": "Managed by Clawrise",
+								"content": "Project Tasks",
 							},
 						},
 					},

--- a/internal/adapter/notion/data_source_test.go
+++ b/internal/adapter/notion/data_source_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -270,6 +271,59 @@ func TestBuildCreateDatabasePayloadRejectsInvalidParent(t *testing.T) {
 	}
 	if appErr.Code != "INVALID_INPUT" {
 		t.Fatalf("unexpected error code: %s", appErr.Code)
+	}
+}
+
+func TestUpdateDataSourceRejectsDescriptionField(t *testing.T) {
+	t.Setenv("NOTION_ACCESS_TOKEN", "notion-token")
+
+	client := newTestClient(t, &roundTripFunc{
+		handler: func(request *http.Request) (*http.Response, error) {
+			t.Fatalf("unexpected request: %s %s", request.Method, request.URL.Path)
+			return nil, nil
+		},
+	})
+
+	_, appErr := client.UpdateDataSource(context.Background(), testStaticProfile(), map[string]any{
+		"data_source_id": "ds_123",
+		"body": map[string]any{
+			"description": []any{
+				map[string]any{
+					"type": "text",
+					"text": map[string]any{
+						"content": "Managed by Clawrise",
+					},
+				},
+			},
+		},
+	})
+	if appErr == nil {
+		t.Fatal("expected UpdateDataSource to reject description field")
+	}
+	if appErr.Code != "INVALID_INPUT" {
+		t.Fatalf("unexpected error code: %s", appErr.Code)
+	}
+	if appErr.Message != dataSourceDescriptionUnsupportedMessage {
+		t.Fatalf("unexpected error message: %s", appErr.Message)
+	}
+}
+
+func TestNotionDataSourceUpdateSpecOmitsDescriptionSample(t *testing.T) {
+	spec := notionDataSourceUpdateSpec()
+
+	body, ok := spec.Input.Sample["body"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected body sample to be an object: %+v", spec.Input.Sample)
+	}
+	if _, exists := body["description"]; exists {
+		t.Fatalf("did not expect description in update sample: %+v", body)
+	}
+	title, ok := body["title"].([]any)
+	if !ok || len(title) == 0 {
+		t.Fatalf("expected title sample in update body: %+v", body)
+	}
+	if len(spec.Input.Notes) < 2 || !strings.Contains(spec.Input.Notes[1], "notion.database.update") {
+		t.Fatalf("expected update note to direct callers to notion.database.update: %+v", spec.Input.Notes)
 	}
 }
 

--- a/internal/adapter/notion/data_source_write.go
+++ b/internal/adapter/notion/data_source_write.go
@@ -11,6 +11,8 @@ import (
 	"github.com/clawrise/clawrise-cli/internal/apperr"
 )
 
+const dataSourceDescriptionUnsupportedMessage = "The `description` property is not supported for data sources. Use the Update Database API instead."
+
 // CreateDataSource 创建一个 Notion data source。
 func (c *Client) CreateDataSource(ctx context.Context, profile ExecutionProfile, input map[string]any) (map[string]any, *apperr.AppError) {
 	payload, appErr := buildDataSourceWritePayload(input, false)
@@ -103,7 +105,13 @@ func buildDataSourceWritePayload(input map[string]any, isUpdate bool) (map[strin
 		if len(body) == 0 {
 			return nil, apperr.New("INVALID_INPUT", "body must not be empty")
 		}
-		return cloneMap(body), nil
+		payload := cloneMap(body)
+		if isUpdate {
+			if appErr := validateDataSourceUpdatePayload(payload); appErr != nil {
+				return nil, appErr
+			}
+		}
+		return payload, nil
 	}
 
 	payload := cloneMap(input)
@@ -115,7 +123,19 @@ func buildDataSourceWritePayload(input map[string]any, isUpdate bool) (map[strin
 		}
 		return nil, apperr.New("INVALID_INPUT", "body is required")
 	}
+	if isUpdate {
+		if appErr := validateDataSourceUpdatePayload(payload); appErr != nil {
+			return nil, appErr
+		}
+	}
 	return payload, nil
+}
+
+func validateDataSourceUpdatePayload(payload map[string]any) *apperr.AppError {
+	if _, exists := payload["description"]; exists {
+		return apperr.New("INVALID_INPUT", dataSourceDescriptionUnsupportedMessage)
+	}
+	return nil
 }
 
 func shouldCreateDatabaseForDataSource(payload map[string]any) bool {

--- a/internal/adapter/notion/p1_p2_test.go
+++ b/internal/adapter/notion/p1_p2_test.go
@@ -204,7 +204,7 @@ func TestDataSourceWriteOperationsSuccess(t *testing.T) {
 				if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
 					t.Fatalf("failed to decode update data source payload: %v", err)
 				}
-				if _, ok := payload["description"].([]any); !ok {
+				if _, ok := payload["title"].([]any); !ok {
 					t.Fatalf("unexpected update payload: %+v", payload)
 				}
 				return jsonResponse(t, http.StatusOK, map[string]any{
@@ -262,11 +262,11 @@ func TestDataSourceWriteOperationsSuccess(t *testing.T) {
 	updated, appErr := client.UpdateDataSource(context.Background(), testStaticProfile(), map[string]any{
 		"data_source_id": "ds_123",
 		"body": map[string]any{
-			"description": []any{
+			"title": []any{
 				map[string]any{
 					"type": "text",
 					"text": map[string]any{
-						"content": "Managed by Clawrise",
+						"content": "Project Tasks Updated",
 					},
 				},
 			},

--- a/scripts/ci/run-notion-live.sh
+++ b/scripts/ci/run-notion-live.sh
@@ -113,8 +113,8 @@ cat > "${CONFIG_PATH}" <<EOF
 defaults:
     platform: notion
     platform_accounts:
-        notion: notion_ci
-    account: notion_ci
+        notion: notion_test_bot
+    account: notion_test_bot
     subject: integration
 auth:
     secret_store:
@@ -128,8 +128,8 @@ runtime:
         base_delay_ms: 200
         max_delay_ms: 1000
 accounts:
-    notion_ci:
-        title: Notion CI
+    notion_test_bot:
+        title: Notion Test Bot
         platform: notion
         subject: integration
         auth:
@@ -185,20 +185,20 @@ extract_json '.platform == "notion"' "${platform_current_output}" >/dev/null
 subject_current_output="$(clawrise_json subject current)"
 extract_json '.subject == "integration"' "${subject_current_output}" >/dev/null
 account_current_output="$(clawrise_json account current)"
-extract_json '.account.name == "notion_ci"' "${account_current_output}" >/dev/null
+extract_json '.account.name == "notion_test_bot"' "${account_current_output}" >/dev/null
 account_list_output="$(clawrise_json account list)"
 extract_json '.accounts | length == 1' "${account_list_output}" >/dev/null
-extract_json '.accounts[0].name == "notion_ci"' "${account_list_output}" >/dev/null
-account_inspect_output="$(clawrise_json account inspect notion_ci)"
+extract_json '.accounts[0].name == "notion_test_bot"' "${account_list_output}" >/dev/null
+account_inspect_output="$(clawrise_json account inspect notion_test_bot)"
 extract_json '.ok == true and .data.platform == "notion" and .data.subject == "integration"' "${account_inspect_output}" >/dev/null
 auth_methods_output="$(clawrise_json auth methods --platform notion)"
 extract_json '.ok == true and (.data.methods | map(.id) | index("notion.internal_token")) != null' "${auth_methods_output}" >/dev/null
 auth_presets_output="$(clawrise_json auth presets --platform notion)"
 extract_json '.ok == true and (.data.presets | map(.id) | index("internal_token")) != null' "${auth_presets_output}" >/dev/null
-auth_inspect_output="$(clawrise_json auth inspect notion_ci)"
+auth_inspect_output="$(clawrise_json auth inspect notion_test_bot)"
 extract_json '.ok == true and .data.ready == true and .data.auth_method == "notion.internal_token"' "${auth_inspect_output}" >/dev/null
 doctor_output="$(clawrise_json doctor)"
-extract_json '.ok == true and .data.defaults.platform == "notion" and .data.defaults.account == "notion_ci"' "${doctor_output}" >/dev/null
+extract_json '.ok == true and .data.defaults.platform == "notion" and .data.defaults.account == "notion_test_bot"' "${doctor_output}" >/dev/null
 spec_list_output="$(clawrise_json spec list notion)"
 extract_json '.ok == true and (.data.items | length) > 0' "${spec_list_output}" >/dev/null
 spec_get_output="$(clawrise_json spec get notion.page.create)"
@@ -209,8 +209,8 @@ extract_json '.ok == true and (.data.written_files | length) >= 1' "${docs_gener
 plugin_list_output="$(clawrise_json plugin list)"
 extract_json '.plugins != null' "${plugin_list_output}" >/dev/null
 
-log "验证 Notion CI 账号鉴权"
-clawrise_json auth check notion_ci >/dev/null
+log "验证 Notion Test Bot 账号鉴权"
+clawrise_json auth check notion_test_bot >/dev/null
 
 log "检查当前 integration 可访问页面，并确认父页面可访问"
 visible_pages_output="$(clawrise_json notion.search.query --json '{"filter":{"property":"object","value":"page"},"page_size":20}')"

--- a/scripts/ci/verify-first-party-provider-smoke.sh
+++ b/scripts/ci/verify-first-party-provider-smoke.sh
@@ -40,7 +40,7 @@ defaults:
   subject: bot
   platform_accounts:
     feishu: feishu_bot
-    notion: notion_bot
+    notion: notion_test_bot
 
 auth:
   secret_store:
@@ -71,8 +71,8 @@ accounts:
       secret_refs:
         app_secret: env:FEISHU_APP_SECRET
 
-  notion_bot:
-    title: Notion Bot
+  notion_test_bot:
+    title: Notion Test Bot
     platform: notion
     subject: integration
     auth:
@@ -121,9 +121,9 @@ assert_contains "${doctor_output}" '"name": "notion"' "doctor output"
 echo "Checking account and default-context commands..."
 account_list_output="$("${cli_bin}" account list)"
 assert_contains "${account_list_output}" '"name": "feishu_bot"' "account list output"
-assert_contains "${account_list_output}" '"name": "notion_bot"' "account list output"
+assert_contains "${account_list_output}" '"name": "notion_test_bot"' "account list output"
 
-account_inspect_output="$("${cli_bin}" account inspect notion_bot)"
+account_inspect_output="$("${cli_bin}" account inspect notion_test_bot)"
 assert_contains "${account_inspect_output}" '"ok": true' "account inspect output"
 assert_contains "${account_inspect_output}" '"method": "notion.internal_token"' "account inspect output"
 
@@ -193,12 +193,12 @@ fish_completion_output="$("${cli_bin}" completion fish)"
 assert_contains "${fish_completion_output}" '# fish completion for clawrise' "fish completion output"
 
 echo "Checking dry-run operation paths..."
-"${cli_bin}" account use notion_bot >/dev/null
+"${cli_bin}" account use notion_test_bot >/dev/null
 
 notion_read_output="$("${cli_bin}" notion.page.get --dry-run --json '{"page_id":"page_demo"}')"
 assert_contains "${notion_read_output}" '"ok": true' "notion page get output"
 assert_contains "${notion_read_output}" '"operation": "notion.page.get"' "notion page get output"
-assert_contains "${notion_read_output}" '"account": "notion_bot"' "notion page get output"
+assert_contains "${notion_read_output}" '"account": "notion_test_bot"' "notion page get output"
 
 notion_write_output="$("${cli_bin}" notion.page.create --dry-run --verify --debug-provider-payload --json '{"title":"Dry Run","parent":{"type":"page_id","id":"page_demo"}}')"
 assert_contains "${notion_write_output}" '"ok": true' "notion page create output"
@@ -213,7 +213,7 @@ assert_contains "${feishu_write_output}" '"operation": "feishu.calendar.event.cr
 assert_contains "${feishu_write_output}" '"account": "feishu_bot"' "feishu calendar create output"
 
 echo "Checking batch execution output..."
-batch_output="$("${cli_bin}" batch --json '{"requests":[{"operation":"feishu.calendar.event.create","dry_run":true,"input":{"calendar_id":"cal_demo","summary":"Batch Smoke 1","start_at":"2026-03-30T10:00:00+08:00","end_at":"2026-03-30T11:00:00+08:00"}},{"operation":"notion.page.get","account":"notion_bot","dry_run":true,"input":{"page_id":"page_demo"}}]}')"
+batch_output="$("${cli_bin}" batch --json '{"requests":[{"operation":"feishu.calendar.event.create","dry_run":true,"input":{"calendar_id":"cal_demo","summary":"Batch Smoke 1","start_at":"2026-03-30T10:00:00+08:00","end_at":"2026-03-30T11:00:00+08:00"}},{"operation":"notion.page.get","account":"notion_test_bot","dry_run":true,"input":{"page_id":"page_demo"}}]}')"
 assert_contains "${batch_output}" '"success_count": 2' "batch output"
 assert_contains "${batch_output}" '"operation": "notion.page.get"' "batch output"
 assert_contains "${batch_output}" '"operation": "feishu.calendar.event.create"' "batch output"


### PR DESCRIPTION
## Summary

This PR fixes the `notion.data_source.update` contract drift reported in #17.

- removes the unsupported `body.description` sample from `spec get notion.data_source.update`
- adds an explicit note directing callers to `notion.database.update` for description changes
- rejects unsupported data source `description` updates locally with a stable `INVALID_INPUT` error before calling Notion upstream
- updates Notion regression tests to cover the supported update path and the rejected description path
- switches Notion smoke/live test scripts to a dedicated `notion_test_bot` account name so test traffic is isolated from the default local integration account

Affected operations / scripts:
- `notion.data_source.update`
- `scripts/ci/run-notion-live.sh`
- `scripts/ci/verify-first-party-provider-smoke.sh`

## Related Issues

- Closes #17
- Related to #N/A

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test only

## Validation

- [x] `go test ./...`
- [x] `go build ./...`
- [x] Manual CLI verification

List key commands or checks you ran:

```bash
go build ./...
go vet ./...
go test ./...
bash -n scripts/ci/verify-first-party-provider-smoke.sh
bash -n scripts/ci/run-notion-live.sh
go run ./cmd/clawrise spec get notion.data_source.update

# manual live verification (sanitized)
go run ./cmd/clawrise notion.data_source.update --account notion_bot --subject integration --input /tmp/update.json
go run ./cmd/clawrise notion.data_source.get --account notion_bot --subject integration --input /tmp/get.json
go run ./cmd/clawrise notion.data_source.update --account notion_bot --subject integration --input /tmp/revert.json
```

## Notes for Reviewers

- The runtime change is intentionally narrow: it blocks only `description` on data source updates, matching current Notion behavior.
- I did not update docs in this PR; the user-facing spec sample/note was the primary misleading surface reported in the issue.
- Live verification used a reversible title update plus readback plus revert on a real Notion data source.

## Checklist

- [ ] I updated docs when behavior changed.
- [x] I sanitized logs, payloads, and examples.
- [x] I kept the pull request focused and reviewable.
