### PR TITLE
Clarify the Notion database description update entry point

### DIFF
--- a/docs/playbooks/en/notion-database-update.md
+++ b/docs/playbooks/en/notion-database-update.md
@@ -1,0 +1,92 @@
+# Update a Notion database description
+
+Operations:
+
+- `notion.database.update`
+- `notion.database.get`
+- `notion.data_source.update` (only for property-level descriptions, not the database-level description)
+
+Use this flow when you need to:
+
+- update a database's top-level description
+- update a database title
+- distinguish database-level description changes from data source property description changes
+
+## 1. Confirm the correct entry point
+
+```bash
+clawrise spec list notion
+clawrise spec list notion.database
+clawrise spec get notion.database.update
+```
+
+Use `notion.database.update` for the **database-level description**.
+Use `notion.data_source.update` only when patching a property's own `description` field.
+
+## 2. Update the database description with the shorthand field
+
+```bash
+clawrise notion.database.update --dry-run --json '{
+  "database_id":"db_demo",
+  "description":"Content master table: one row per item, aggregating current state and rolling metrics."
+}'
+```
+
+The top-level `description` field accepts a plain string and Clawrise will translate it into the rich_text array required by Notion.
+
+## 3. Update the database description with provider-native `body.description`
+
+```bash
+clawrise notion.database.update --dry-run --json '{
+  "database_id":"db_demo",
+  "body":{
+    "description":[
+      {
+        "type":"text",
+        "text":{
+          "content":"Content master table: one row per item, aggregating current state and rolling metrics."
+        }
+      }
+    ]
+  }
+}'
+```
+
+Use this form when you are already working directly with the upstream Notion payload shape.
+
+## 4. Read the database back
+
+```bash
+clawrise notion.database.get --json '{"database_id":"db_demo"}'
+```
+
+Focus on these fields in the response:
+
+- `description`
+- `description_rich_text`
+- `raw.description`
+
+## 5. Do not send the database description through `notion.data_source.update.body.description`
+
+```bash
+clawrise notion.data_source.update --dry-run --json '{
+  "data_source_id":"ds_demo",
+  "body":{
+    "description":[
+      {
+        "type":"text",
+        "text":{"content":"This will fail"}
+      }
+    ]
+  }
+}'
+```
+
+That field is not supported by Notion's data source update API. Switch back to `notion.database.update` when you need to change the database-level description.
+
+## Verification tips
+
+- Run `clawrise spec get notion.database.update` first
+- Prefer the shorthand `description` field if you are unsure about the raw payload shape
+- Use `--dry-run` before sending the live request
+- Read the database back with `notion.database.get` after the write

--- a/docs/playbooks/index.yaml
+++ b/docs/playbooks/index.yaml
@@ -1,5 +1,5 @@
 version: 1
-updated_at: "2026-04-02"
+updated_at: "2026-04-17"
 playbooks:
   - id: feishu-document-update
     title: 更新飞书文档
@@ -91,3 +91,19 @@ playbooks:
       - read
     zh_path: docs/playbooks/zh/notion-data-source-query.md
     en_path: docs/playbooks/en/notion-data-source-query.md
+  - id: notion-database-update
+    title: 更新 Notion database 顶层 description
+    title_en: Update a Notion database description
+    platform: notion
+    operations:
+      - notion.database.update
+      - notion.database.get
+      - notion.data_source.update
+    tags:
+      - notion
+      - database
+      - description
+      - write
+      - dry-run
+    zh_path: docs/playbooks/zh/notion-database-update.md
+    en_path: docs/playbooks/en/notion-database-update.md

--- a/docs/playbooks/zh/notion-database-update.md
+++ b/docs/playbooks/zh/notion-database-update.md
@@ -1,0 +1,92 @@
+# 更新 Notion database 顶层 description
+
+适用 operation：
+
+- `notion.database.update`
+- `notion.database.get`
+- `notion.data_source.update`（仅用于 property-level description，不用于 database 顶层 description）
+
+适用场景：
+
+- 更新 database 顶层 description
+- 更新 database 标题
+- 明确区分 database 顶层 description 与 data source property description
+
+## 1. 先确认正确入口
+
+```bash
+clawrise spec list notion
+clawrise spec list notion.database
+clawrise spec get notion.database.update
+```
+
+如果你要改的是 **database 顶层 description**，请使用 `notion.database.update`。
+如果你要改的是某个 property 的 `description`，请继续使用 `notion.data_source.update` 并传完整 property schema patch。
+
+## 2. 用简写字段更新 database description
+
+```bash
+clawrise notion.database.update --dry-run --json '{
+  "database_id":"db_demo",
+  "description":"内容主表：一条内容一行；聚合当前状态与近窗指标。"
+}'
+```
+
+这里的 `description` 可以直接传字符串，Clawrise 会自动转成 Notion 需要的 rich_text 数组。
+
+## 3. 用 provider-native body.description 更新
+
+```bash
+clawrise notion.database.update --dry-run --json '{
+  "database_id":"db_demo",
+  "body":{
+    "description":[
+      {
+        "type":"text",
+        "text":{
+          "content":"内容主表：一条内容一行；聚合当前状态与近窗指标。"
+        }
+      }
+    ]
+  }
+}'
+```
+
+当你已经在上游 payload 级别工作，或者需要自己控制 rich_text 结构时，使用这种写法。
+
+## 4. 回读确认
+
+```bash
+clawrise notion.database.get --json '{"database_id":"db_demo"}'
+```
+
+返回结果里可以重点看：
+
+- `description`
+- `description_rich_text`
+- `raw.description`
+
+## 5. 不要把 database description 写到 notion.data_source.update.body.description
+
+```bash
+clawrise notion.data_source.update --dry-run --json '{
+  "data_source_id":"ds_demo",
+  "body":{
+    "description":[
+      {
+        "type":"text",
+        "text":{"content":"这会失败"}
+      }
+    ]
+  }
+}'
+```
+
+这个字段不被 Notion 的 data source update API 支持。若要更新 database 顶层 description，请切回 `notion.database.update`。
+
+## 验证建议
+
+- 先运行 `clawrise spec get notion.database.update`
+- 不确定 payload 形状时，优先用顶层简写 `description`
+- 真正写入前先加 `--dry-run`
+- 写入后用 `notion.database.get` 回读确认

--- a/internal/adapter/notion/data_source_spec.go
+++ b/internal/adapter/notion/data_source_spec.go
@@ -82,7 +82,7 @@ func notionDataSourceUpdateSpec() adapter.OperationSpec {
 			Required: []string{"data_source_id", "body"},
 			Notes: []string{
 				"`body` is passed through to the Notion update data source API as-is.",
-				"`body.description` is not supported by Notion for data source updates; use `notion.database.update` for database descriptions.",
+				"`body.description` is not supported by Notion for data source updates; use `notion.database.update` for database descriptions and run `clawrise spec get notion.database.update` for the supported request shape.",
 			},
 			Sample: map[string]any{
 				"data_source_id": "ds_demo",

--- a/internal/adapter/notion/database_spec.go
+++ b/internal/adapter/notion/database_spec.go
@@ -45,18 +45,43 @@ func notionDatabaseCreateSpec() adapter.OperationSpec {
 
 func notionDatabaseUpdateSpec() adapter.OperationSpec {
 	return adapter.OperationSpec{
-		Summary: "Update a Notion database.",
+		Summary:     "Update a Notion database, including its top-level description.",
+		Description: "Use this operation when you need to change database-level metadata such as the database title or top-level description. `notion.data_source.update` cannot update `body.description` for a database's underlying data source.",
 		Input: adapter.InputSpec{
 			Required: []string{"database_id"},
 			Optional: []string{"body", "parent", "title", "description", "in_trash", "is_locked", "icon", "cover"},
 			Notes: []string{
 				"Provide either `body`, or one or more top-level shorthand fields for common database updates.",
+				"Use this operation for top-level database description updates; `notion.data_source.update` only supports property-level description changes.",
+				"`description` accepts either a plain string or a provider-native rich_text array. Use `body.description` only when you want to send the raw Notion patch payload yourself.",
 				"`parent.type` supports `page_id`, `database_id`, or `workspace`.",
 			},
 			Sample: map[string]any{
 				"database_id": "db_demo",
 				"title":       "Project Hub",
 				"description": "Managed by Clawrise",
+			},
+		},
+		Examples: []adapter.ExampleSpec{
+			{
+				Title:   "List database operations from the Notion capability tree",
+				Command: `clawrise spec list notion.database`,
+			},
+			{
+				Title:   "Inspect the database update input contract",
+				Command: `clawrise spec get notion.database.update`,
+			},
+			{
+				Title:   "Update a database description with shorthand text",
+				Command: `clawrise notion.database.update --dry-run --json '{"database_id":"db_demo","description":"Managed by Clawrise"}'`,
+			},
+			{
+				Title:   "Update a database description with provider-native rich text",
+				Command: `clawrise notion.database.update --dry-run --json '{"database_id":"db_demo","body":{"description":[{"type":"text","text":{"content":"Managed by Clawrise"}}]}}'`,
+			},
+			{
+				Title:   "Read the database back after the update",
+				Command: `clawrise notion.database.get --json '{"database_id":"db_demo"}'`,
 			},
 		},
 	}

--- a/internal/adapter/notion/database_spec_test.go
+++ b/internal/adapter/notion/database_spec_test.go
@@ -1,0 +1,56 @@
+package notion
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNotionDatabaseUpdateSpecDocumentsDescriptionEntryPoint(t *testing.T) {
+	spec := notionDatabaseUpdateSpec()
+
+	if !strings.Contains(spec.Description, "notion.data_source.update") {
+		t.Fatalf("expected database update description to reference notion.data_source.update: %s", spec.Description)
+	}
+	if len(spec.Input.Notes) < 3 {
+		t.Fatalf("expected database update notes to document description usage: %+v", spec.Input.Notes)
+	}
+	if !strings.Contains(spec.Input.Notes[1], "top-level database description") {
+		t.Fatalf("expected note to mention top-level database descriptions: %+v", spec.Input.Notes)
+	}
+	if !strings.Contains(spec.Input.Notes[2], "rich_text") {
+		t.Fatalf("expected note to explain raw rich_text support: %+v", spec.Input.Notes)
+	}
+	if got := spec.Input.Sample["description"]; got != "Managed by Clawrise" {
+		t.Fatalf("unexpected database update description sample: %+v", spec.Input.Sample)
+	}
+}
+
+func TestNotionDatabaseUpdateSpecIncludesDiscoveryAndUpdateExamples(t *testing.T) {
+	spec := notionDatabaseUpdateSpec()
+
+	if len(spec.Examples) < 5 {
+		t.Fatalf("expected database update examples to cover discovery and usage: %+v", spec.Examples)
+	}
+
+	commands := make([]string, 0, len(spec.Examples))
+	for _, example := range spec.Examples {
+		commands = append(commands, example.Command)
+	}
+
+	assertContainsExampleCommand(t, commands, "clawrise spec list notion.database")
+	assertContainsExampleCommand(t, commands, "clawrise spec get notion.database.update")
+	assertContainsExampleCommand(t, commands, "clawrise notion.database.update --dry-run --json")
+	assertContainsExampleCommand(t, commands, "\"description\":\"Managed by Clawrise\"")
+	assertContainsExampleCommand(t, commands, "\"body\":{\"description\":[{\"type\":\"text\"")
+	assertContainsExampleCommand(t, commands, "clawrise notion.database.get --json")
+}
+
+func assertContainsExampleCommand(t *testing.T, commands []string, fragment string) {
+	t.Helper()
+	for _, command := range commands {
+		if strings.Contains(command, fragment) {
+			return
+		}
+	}
+	t.Fatalf("expected one example command to contain %q in %+v", fragment, commands)
+}

--- a/internal/metadata/service_test.go
+++ b/internal/metadata/service_test.go
@@ -3,11 +3,14 @@ package metadata
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/clawrise/clawrise-cli/internal/adapter"
+	feishuadapter "github.com/clawrise/clawrise-cli/internal/adapter/feishu"
+	notionadapter "github.com/clawrise/clawrise-cli/internal/adapter/notion"
 )
 
 func TestValidatePlaybooksFilePassesForRegisteredOperations(t *testing.T) {
@@ -82,6 +85,48 @@ playbooks:
 	}
 	if len(result.Issues) == 0 || !strings.Contains(result.Issues[0].Code, "PLAYBOOK_OPERATION_NOT_FOUND") {
 		t.Fatalf("expected missing operation issue, got: %+v", result.Issues)
+	}
+}
+
+func TestValidateProjectPlaybooksIndex(t *testing.T) {
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("failed to resolve current test file path")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(currentFile), "..", ".."))
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd returned error: %v", err)
+	}
+	if err := os.Chdir(repoRoot); err != nil {
+		t.Fatalf("Chdir returned error: %v", err)
+	}
+	defer func() {
+		_ = os.Chdir(cwd)
+	}()
+
+	registry := adapter.NewRegistry()
+
+	feishuClient, err := feishuadapter.NewClient(feishuadapter.Options{})
+	if err != nil {
+		t.Fatalf("failed to construct feishu client: %v", err)
+	}
+	notionClient, err := notionadapter.NewClient(notionadapter.Options{})
+	if err != nil {
+		t.Fatalf("failed to construct notion client: %v", err)
+	}
+
+	feishuadapter.RegisterOperations(registry, feishuClient)
+	notionadapter.RegisterOperations(registry, notionClient)
+
+	service := NewServiceWithCatalog(registry, nil)
+	result, err := service.ValidatePlaybooks()
+	if err != nil {
+		t.Fatalf("ValidatePlaybooks returned error: %v", err)
+	}
+	if !result.OK || result.InvalidCount != 0 {
+		t.Fatalf("expected project playbooks to validate cleanly, got %+v", result)
 	}
 }
 

--- a/internal/spec/service.go
+++ b/internal/spec/service.go
@@ -48,6 +48,7 @@ func (s *Service) List(path string) (ListResult, error) {
 
 	itemsByPath := map[string]*ListItem{}
 	childrenByPath := map[string]map[string]struct{}{}
+	directOperationsByPath := map[string]map[string]struct{}{}
 	hasMatch := path == ""
 
 	for _, definition := range definitions {
@@ -85,6 +86,12 @@ func (s *Service) List(path string) (ListResult, error) {
 		}
 
 		item.OperationCount++
+		if len(opParts) == childDepth+1 {
+			if _, ok := directOperationsByPath[childFullPath]; !ok {
+				directOperationsByPath[childFullPath] = map[string]struct{}{}
+			}
+			directOperationsByPath[childFullPath][definition.Operation] = struct{}{}
+		}
 		if len(opParts) > childDepth {
 			if _, ok := childrenByPath[childFullPath]; !ok {
 				childrenByPath[childFullPath] = map[string]struct{}{}
@@ -101,6 +108,13 @@ func (s *Service) List(path string) (ListResult, error) {
 	for _, item := range itemsByPath {
 		if item.NodeType != "operation" {
 			item.ChildCount = len(childrenByPath[item.FullPath])
+			if operations := directOperationsByPath[item.FullPath]; len(operations) > 0 {
+				item.DirectOperations = make([]string, 0, len(operations))
+				for operation := range operations {
+					item.DirectOperations = append(item.DirectOperations, operation)
+				}
+				sort.Strings(item.DirectOperations)
+			}
 		}
 		items = append(items, *item)
 	}

--- a/internal/spec/service_test.go
+++ b/internal/spec/service_test.go
@@ -54,6 +54,43 @@ func TestServiceListGroup(t *testing.T) {
 	}
 }
 
+func TestServiceListPlatformIncludesDirectOperationsPreview(t *testing.T) {
+	registry := newTestRegistry(t)
+	service := NewServiceWithCatalog(registry, catalogEntriesFromRegistry(registry))
+
+	result, err := service.List("notion")
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+
+	var databaseItem *ListItem
+	for index := range result.Items {
+		if result.Items[index].FullPath == "notion.database" {
+			databaseItem = &result.Items[index]
+			break
+		}
+	}
+	if databaseItem == nil {
+		t.Fatalf("expected notion.database item in %+v", result.Items)
+	}
+	if databaseItem.OperationCount != 3 {
+		t.Fatalf("expected notion.database operation count 3, got %+v", databaseItem)
+	}
+	expected := []string{
+		"notion.database.create",
+		"notion.database.get",
+		"notion.database.update",
+	}
+	if len(databaseItem.DirectOperations) != len(expected) {
+		t.Fatalf("unexpected direct operations: %+v", databaseItem.DirectOperations)
+	}
+	for index, operation := range expected {
+		if databaseItem.DirectOperations[index] != operation {
+			t.Fatalf("unexpected direct operations: %+v", databaseItem.DirectOperations)
+		}
+	}
+}
+
 func TestServiceGetOperation(t *testing.T) {
 	registry := newTestRegistry(t)
 	service := NewServiceWithCatalog(registry, catalogEntriesFromRegistry(registry))

--- a/internal/spec/types.go
+++ b/internal/spec/types.go
@@ -21,14 +21,15 @@ func newError(code, message string) *Error {
 
 // ListItem describes one node returned by `spec list`.
 type ListItem struct {
-	Name           string `json:"name"`
-	FullPath       string `json:"full_path"`
-	NodeType       string `json:"node_type"`
-	ChildCount     int    `json:"child_count,omitempty"`
-	OperationCount int    `json:"operation_count,omitempty"`
-	Implemented    *bool  `json:"implemented,omitempty"`
-	Mutating       *bool  `json:"mutating,omitempty"`
-	Summary        string `json:"summary,omitempty"`
+	Name             string   `json:"name"`
+	FullPath         string   `json:"full_path"`
+	NodeType         string   `json:"node_type"`
+	ChildCount       int      `json:"child_count,omitempty"`
+	OperationCount   int      `json:"operation_count,omitempty"`
+	DirectOperations []string `json:"direct_operations,omitempty"`
+	Implemented      *bool    `json:"implemented,omitempty"`
+	Mutating         *bool    `json:"mutating,omitempty"`
+	Summary          string   `json:"summary,omitempty"`
 }
 
 // ListResult describes one hierarchical browse result.


### PR DESCRIPTION
## Summary

Clarify the supported entry point for updating a Notion database's top-level description.

This PR keeps the existing `notion.database.update` implementation, but makes it easier to discover and safer to use by:
- surfacing direct child operations in `spec list` group results
- expanding the `notion.database.update` spec with clearer notes and runnable examples
- pointing `notion.data_source.update` callers at the correct database update entry point
- adding a dedicated playbook for database-level description updates
- validating the checked-in playbook index against the real registered operations

## Related Issues

- Closes #19
- Related to #17

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Test only

## Validation

- [x] `go test ./...`
- [x] `go build ./...`
- [ ] Manual CLI verification

List key commands or checks you ran:

```bash
go test ./...
go build ./...
go test ./internal/metadata ./internal/spec ./internal/adapter/notion
go run ./cmd/clawrise spec list notion.database
go run ./cmd/clawrise spec get notion.database.update
```

## Notes for Reviewers

The main structural change is adding `direct_operations` as an additive field on grouped `spec list` results so callers can discover leaf operations like `notion.database.update` without drilling down manually.

I also added a metadata test that validates the real checked-in `docs/playbooks/index.yaml` against the registered Feishu/Notion operations, so future docs/index drift gets caught by CI.

I left manual CLI verification unchecked because local `clawrise` runs still depend on the installed plugin/runtime state; end-to-end confirmation of the updated Notion spec surface requires rebuilding or reinstalling the local Notion plugin.

## Checklist

- [x] I updated docs when behavior changed.
- [x] I sanitized logs, payloads, and examples.
- [x] I kept the pull request focused and reviewable.
