### PR TITLE
Add Notion safety guards for child-page deletes and markdown references

### DIFF
--- a/docs/en/mvp-operation-spec.md
+++ b/docs/en/mvp-operation-spec.md
@@ -749,6 +749,11 @@ Supported command types:
 - `insert_content`
 - `replace_content_range`
 
+Safety notes:
+
+- inline page and database mentions must use `<mention-page>` and `<mention-database>`
+- standalone `<page>` and `<database>` tags are block references and must appear on their own line
+
 Allowed subject:
 
 - `integration`

--- a/docs/en/mvp-operation-spec.md
+++ b/docs/en/mvp-operation-spec.md
@@ -874,9 +874,19 @@ Required fields:
 
 - `block_id`
 
+Optional fields:
+
+- `allow_child_page_delete`
+
 Allowed subject:
 
 - `integration`
+
+Safety notes:
+
+- deleting a `child_page` block can archive/trash the underlying Notion page, not merely remove one visual entry
+- keep `allow_child_page_delete` unset unless you intentionally want to archive that page
+- if the integration lacks Notion read content capability, the adapter cannot inspect the target type and will require `allow_child_page_delete=true` before deleting
 
 Success output should include:
 

--- a/docs/playbooks/en/notion-page-update.md
+++ b/docs/playbooks/en/notion-page-update.md
@@ -58,3 +58,8 @@ clawrise notion.page.markdown.update --dry-run --json '{
   }
 }'
 ```
+
+For Notion enhanced markdown:
+
+- use `<mention-page>` and `<mention-database>` for inline mentions inside sentences or list items
+- use `<page>` and `<database>` only as standalone block references on their own line

--- a/docs/playbooks/zh/notion-page-update.md
+++ b/docs/playbooks/zh/notion-page-update.md
@@ -67,6 +67,11 @@ clawrise notion.page.markdown.update --dry-run --json '{
 }'
 ```
 
+对于 Notion enhanced markdown：
+
+- 句子或列表项里的行内提及要用 `<mention-page>` 和 `<mention-database>`
+- `<page>` 和 `<database>` 只应用作独立 block 引用，必须单独占一行
+
 真正写入时移除 `--dry-run` 即可。
 
 ## 验证建议

--- a/docs/zh/mvp-operation-spec.md
+++ b/docs/zh/mvp-operation-spec.md
@@ -779,6 +779,11 @@ MVP 限制：
 - `insert_content`
 - `replace_content_range`
 
+安全说明：
+
+- 行内页面/数据库提及必须使用 `<mention-page>` 和 `<mention-database>`
+- 独立的 `<page>` 和 `<database>` 标签表示 block 级引用，必须单独占一行
+
 允许主体：
 
 - `integration`

--- a/docs/zh/mvp-operation-spec.md
+++ b/docs/zh/mvp-operation-spec.md
@@ -904,9 +904,19 @@ MVP 限制：
 
 - `block_id`
 
+可选字段：
+
+- `allow_child_page_delete`
+
 允许主体：
 
 - `integration`
+
+安全说明：
+
+- 删除 `child_page` block 可能会归档/移入回收站其底层 Notion 页面，不只是移除一个视觉入口
+- 只有在你明确要归档该页面时才应设置 `allow_child_page_delete=true`
+- 如果集成缺少 Notion 的 read content capability，适配器无法安全判断目标类型，也会要求显式设置 `allow_child_page_delete=true` 才允许删除
 
 成功输出建议包含：
 

--- a/internal/adapter/notion/block.go
+++ b/internal/adapter/notion/block.go
@@ -272,8 +272,16 @@ func (c *Client) UpdateBlock(ctx context.Context, profile ExecutionProfile, inpu
 
 // DeleteBlock moves the specified block to the trash.
 func (c *Client) DeleteBlock(ctx context.Context, profile ExecutionProfile, input map[string]any) (map[string]any, *apperr.AppError) {
+	if appErr := validateTopLevelInputFields("notion.block.delete", input, notionBlockDeleteSpec().Input, nil); appErr != nil {
+		return nil, appErr
+	}
+
 	blockID, appErr := requireIDField(input, "block_id")
 	if appErr != nil {
+		return nil, appErr
+	}
+
+	if appErr := c.guardChildPageDelete(ctx, profile, blockID, input); appErr != nil {
 		return nil, appErr
 	}
 
@@ -304,6 +312,35 @@ func (c *Client) DeleteBlock(ctx context.Context, profile ExecutionProfile, inpu
 	data := normalizeBlockData(block)
 	data["deleted"] = true
 	return data, nil
+}
+
+func (c *Client) guardChildPageDelete(ctx context.Context, profile ExecutionProfile, blockID string, input map[string]any) *apperr.AppError {
+	if allowed, _ := asBool(input["allow_child_page_delete"]); allowed {
+		return nil
+	}
+
+	blockData, appErr := c.GetBlock(ctx, profile, map[string]any{
+		"block_id": blockID,
+	})
+	if appErr != nil {
+		if appErr.Code == "PERMISSION_DENIED" {
+			return apperr.New(
+				"UNSAFE_BLOCK_DELETE",
+				"unable to inspect the block type before delete because Notion read content capability is missing; deleting a child_page can archive/trash the underlying page; grant read content or set allow_child_page_delete=true to continue",
+			)
+		}
+		return appErr
+	}
+
+	blockType, _ := asString(blockData["type"])
+	if strings.TrimSpace(blockType) != "child_page" {
+		return nil
+	}
+
+	return apperr.New(
+		"UNSAFE_BLOCK_DELETE",
+		"target block is a child_page; deleting it can archive/trash the underlying Notion page; set allow_child_page_delete=true to continue",
+	)
 }
 
 // buildBlockChildren 将 Clawrise shorthand 与 provider-native block body 统一映射为 Notion blocks。

--- a/internal/adapter/notion/block_spec.go
+++ b/internal/adapter/notion/block_spec.go
@@ -126,8 +126,24 @@ func notionBlockDeleteSpec() adapter.OperationSpec {
 		Summary: "Archive a Notion block.",
 		Input: adapter.InputSpec{
 			Required: []string{"block_id"},
+			Optional: []string{"allow_child_page_delete"},
+			Notes: []string{
+				"Deleting a `child_page` block can archive/trash the underlying Notion page, not just remove one visual entry.",
+				"Set `allow_child_page_delete=true` only when you intentionally want that destructive behavior.",
+				"If the integration lacks Notion read content capability, the adapter cannot inspect the block type safely and will also require `allow_child_page_delete=true` before deleting.",
+			},
 			Sample: map[string]any{
 				"block_id": "blk_demo",
+			},
+		},
+		Examples: []adapter.ExampleSpec{
+			{
+				Title:   "Delete a regular block",
+				Command: `clawrise notion.block.delete --json '{"block_id":"blk_demo"}'`,
+			},
+			{
+				Title:   "Explicitly allow deleting a child_page block",
+				Command: `clawrise notion.block.delete --json '{"block_id":"blk_child_page","allow_child_page_delete":true}'`,
 			},
 		},
 	}

--- a/internal/adapter/notion/client_test.go
+++ b/internal/adapter/notion/client_test.go
@@ -1653,32 +1653,54 @@ func TestUpdateBlockVerifyAfterWriteSuccess(t *testing.T) {
 func TestDeleteBlockSuccess(t *testing.T) {
 	t.Setenv("NOTION_ACCESS_TOKEN", "notion-token")
 
+	requestCount := 0
 	transport := &roundTripFunc{
 		handler: func(request *http.Request) (*http.Response, error) {
 			if request.URL.Path != "/v1/blocks/block_demo" {
 				t.Fatalf("unexpected request path: %s", request.URL.Path)
 			}
-			if request.Method != http.MethodDelete {
-				t.Fatalf("unexpected method: %s", request.Method)
-			}
-
-			return jsonResponse(t, http.StatusOK, map[string]any{
-				"id":           "block_demo",
-				"type":         "paragraph",
-				"has_children": false,
-				"in_trash":     true,
-				"paragraph": map[string]any{
-					"rich_text": []map[string]any{
-						{
-							"type":       "text",
-							"plain_text": "待删除正文",
-							"text": map[string]any{
-								"content": "待删除正文",
+			requestCount++
+			switch request.Method {
+			case http.MethodGet:
+				return jsonResponse(t, http.StatusOK, map[string]any{
+					"id":           "block_demo",
+					"type":         "paragraph",
+					"has_children": false,
+					"in_trash":     false,
+					"paragraph": map[string]any{
+						"rich_text": []map[string]any{
+							{
+								"type":       "text",
+								"plain_text": "待删除正文",
+								"text": map[string]any{
+									"content": "待删除正文",
+								},
 							},
 						},
 					},
-				},
-			}), nil
+				}), nil
+			case http.MethodDelete:
+				return jsonResponse(t, http.StatusOK, map[string]any{
+					"id":           "block_demo",
+					"type":         "paragraph",
+					"has_children": false,
+					"in_trash":     true,
+					"paragraph": map[string]any{
+						"rich_text": []map[string]any{
+							{
+								"type":       "text",
+								"plain_text": "待删除正文",
+								"text": map[string]any{
+									"content": "待删除正文",
+								},
+							},
+						},
+					},
+				}), nil
+			default:
+				t.Fatalf("unexpected method: %s", request.Method)
+				return nil, nil
+			}
 		},
 	}
 
@@ -1694,6 +1716,132 @@ func TestDeleteBlockSuccess(t *testing.T) {
 	}
 	if data["archived"] != true {
 		t.Fatalf("unexpected archived flag: %+v", data["archived"])
+	}
+	if requestCount != 2 {
+		t.Fatalf("expected guard GET plus DELETE, got %d requests", requestCount)
+	}
+}
+
+func TestDeleteBlockChildPageRequiresOverride(t *testing.T) {
+	t.Setenv("NOTION_ACCESS_TOKEN", "notion-token")
+
+	requestCount := 0
+	transport := &roundTripFunc{
+		handler: func(request *http.Request) (*http.Response, error) {
+			if request.URL.Path != "/v1/blocks/block_demo" {
+				t.Fatalf("unexpected request path: %s", request.URL.Path)
+			}
+			requestCount++
+			if request.Method != http.MethodGet {
+				t.Fatalf("unexpected method: %s", request.Method)
+			}
+
+			return jsonResponse(t, http.StatusOK, map[string]any{
+				"id":           "block_demo",
+				"type":         "child_page",
+				"has_children": false,
+				"in_trash":     false,
+				"child_page": map[string]any{
+					"title": "Dangerous child page",
+				},
+			}), nil
+		},
+	}
+
+	client := newTestClient(t, transport)
+	data, appErr := client.DeleteBlock(context.Background(), testStaticProfile(), map[string]any{
+		"block_id": "block_demo",
+	})
+	if appErr == nil {
+		t.Fatalf("expected unsafe delete error, got data: %+v", data)
+	}
+	if appErr.Code != "UNSAFE_BLOCK_DELETE" {
+		t.Fatalf("unexpected error code: %+v", appErr)
+	}
+	if requestCount != 1 {
+		t.Fatalf("expected only the guard GET request, got %d requests", requestCount)
+	}
+}
+
+func TestDeleteBlockChildPageAllowedWithOverride(t *testing.T) {
+	t.Setenv("NOTION_ACCESS_TOKEN", "notion-token")
+
+	requestCount := 0
+	transport := &roundTripFunc{
+		handler: func(request *http.Request) (*http.Response, error) {
+			if request.URL.Path != "/v1/blocks/block_demo" {
+				t.Fatalf("unexpected request path: %s", request.URL.Path)
+			}
+			requestCount++
+			switch request.Method {
+			case http.MethodDelete:
+				return jsonResponse(t, http.StatusOK, map[string]any{
+					"id":           "block_demo",
+					"type":         "child_page",
+					"has_children": false,
+					"in_trash":     true,
+					"child_page": map[string]any{
+						"title": "Dangerous child page",
+					},
+				}), nil
+			default:
+				t.Fatalf("unexpected method: %s", request.Method)
+				return nil, nil
+			}
+		},
+	}
+
+	client := newTestClient(t, transport)
+	data, appErr := client.DeleteBlock(context.Background(), testStaticProfile(), map[string]any{
+		"block_id":                "block_demo",
+		"allow_child_page_delete": true,
+	})
+	if appErr != nil {
+		t.Fatalf("DeleteBlock returned error: %+v", appErr)
+	}
+	if data["deleted"] != true {
+		t.Fatalf("unexpected deleted flag: %+v", data["deleted"])
+	}
+	if requestCount != 1 {
+		t.Fatalf("expected a direct DELETE when override is set, got %d requests", requestCount)
+	}
+}
+
+func TestDeleteBlockRequiresOverrideWhenGuardCannotInspectType(t *testing.T) {
+	t.Setenv("NOTION_ACCESS_TOKEN", "notion-token")
+
+	requestCount := 0
+	transport := &roundTripFunc{
+		handler: func(request *http.Request) (*http.Response, error) {
+			if request.URL.Path != "/v1/blocks/block_demo" {
+				t.Fatalf("unexpected request path: %s", request.URL.Path)
+			}
+			requestCount++
+			if request.Method != http.MethodGet {
+				t.Fatalf("unexpected method: %s", request.Method)
+			}
+
+			return jsonResponse(t, http.StatusForbidden, map[string]any{
+				"object":  "error",
+				"status":  http.StatusForbidden,
+				"code":    "restricted_resource",
+				"message": "API token does not have read content capabilities.",
+			}), nil
+		},
+	}
+
+	client := newTestClient(t, transport)
+	data, appErr := client.DeleteBlock(context.Background(), testStaticProfile(), map[string]any{
+		"block_id": "block_demo",
+	})
+	if appErr == nil {
+		t.Fatalf("expected unsafe delete error, got data: %+v", data)
+	}
+	if appErr.Code != "UNSAFE_BLOCK_DELETE" {
+		t.Fatalf("unexpected error code: %+v", appErr)
+	}
+	if requestCount != 1 {
+		t.Fatalf("expected only the guard GET request, got %d requests", requestCount)
 	}
 }
 

--- a/internal/adapter/notion/page.go
+++ b/internal/adapter/notion/page.go
@@ -646,6 +646,9 @@ func extractCreatePageMarkdown(input map[string]any) (string, bool, *apperr.AppE
 	if !ok {
 		return "", false, apperr.New("INVALID_INPUT", "markdown must be a string")
 	}
+	if appErr := validateEnhancedMarkdownInlineReferences(markdown); appErr != nil {
+		return "", false, appErr
+	}
 	return markdown, true, nil
 }
 
@@ -904,6 +907,9 @@ func buildUpdateContentCommand(raw any) (map[string]any, *apperr.AppError) {
 		if !ok {
 			return nil, apperr.New("INVALID_INPUT", "new_str is required for each content update")
 		}
+		if appErr := validateEnhancedMarkdownInlineReferences(newStr); appErr != nil {
+			return nil, appErr
+		}
 
 		update := map[string]any{
 			"old_str": strings.TrimSpace(oldStr),
@@ -933,6 +939,9 @@ func buildReplaceContentCommand(raw any) (map[string]any, *apperr.AppError) {
 	if !ok {
 		return nil, apperr.New("INVALID_INPUT", "replace_content.new_str is required")
 	}
+	if appErr := validateEnhancedMarkdownInlineReferences(newStr); appErr != nil {
+		return nil, appErr
+	}
 
 	result := map[string]any{
 		"new_str": newStr,
@@ -951,6 +960,9 @@ func buildInsertContentCommand(raw any) (map[string]any, *apperr.AppError) {
 	content, ok := asString(command["content"])
 	if !ok {
 		return nil, apperr.New("INVALID_INPUT", "insert_content.content is required")
+	}
+	if appErr := validateEnhancedMarkdownInlineReferences(content); appErr != nil {
+		return nil, appErr
 	}
 
 	result := map[string]any{
@@ -971,6 +983,9 @@ func buildReplaceContentRangeCommand(raw any) (map[string]any, *apperr.AppError)
 	if !ok {
 		return nil, apperr.New("INVALID_INPUT", "replace_content_range.content is required")
 	}
+	if appErr := validateEnhancedMarkdownInlineReferences(content); appErr != nil {
+		return nil, appErr
+	}
 	contentRange, ok := asString(command["content_range"])
 	if !ok || strings.TrimSpace(contentRange) == "" {
 		return nil, apperr.New("INVALID_INPUT", "replace_content_range.content_range is required")
@@ -984,4 +999,52 @@ func buildReplaceContentRangeCommand(raw any) (map[string]any, *apperr.AppError)
 		result["allow_deleting_content"] = allowDeletingContent
 	}
 	return result, nil
+}
+
+func validateEnhancedMarkdownInlineReferences(markdown string) *apperr.AppError {
+	lines := strings.Split(markdown, "\n")
+	inFence := false
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "```") {
+			inFence = !inFence
+			continue
+		}
+		if inFence {
+			continue
+		}
+		if !strings.Contains(line, "<page ") && !strings.Contains(line, "<database ") {
+			continue
+		}
+		if isStandaloneReferenceLine(trimmed) {
+			continue
+		}
+
+		return apperr.New(
+			"INVALID_INPUT",
+			"inline <page> and <database> tags are not supported by Notion enhanced markdown; use standalone block references on their own line or inline <mention-page>/<mention-database> tags instead",
+		)
+	}
+
+	return nil
+}
+
+func isStandaloneReferenceLine(line string) bool {
+	for _, tag := range []string{"page", "database"} {
+		open := "<" + tag
+		close := "</" + tag + ">"
+		if !strings.HasPrefix(line, open) {
+			continue
+		}
+		if !strings.HasSuffix(line, close) {
+			return false
+		}
+		openEnd := strings.Index(line, ">")
+		if openEnd == -1 || openEnd < len(open) {
+			return false
+		}
+		return true
+	}
+	return false
 }

--- a/internal/adapter/notion/page_spec.go
+++ b/internal/adapter/notion/page_spec.go
@@ -13,6 +13,7 @@ func notionPageCreateSpec() adapter.OperationSpec {
 				"When using a public integration, `parent` may be omitted for workspace-level page creation.",
 				"`children` supports both shorthand top-level block fields and provider-native nested block bodies.",
 				"`markdown` is mutually exclusive with `children` and follows the Notion markdown page API.",
+				"When `markdown` contains inline page or database mentions, use `<mention-page>` and `<mention-database>`; standalone `<page>` and `<database>` tags are block references and must stay on their own line.",
 				"`template` cannot be combined with `children` or `markdown` because Notion applies template content asynchronously.",
 				"`position` customizes where the child page mention is inserted when the parent is a page; `after` is a shorthand alias for `position.type=after_block`.",
 				"When both shorthand and provider-native fields are present on the same block, the top-level fields take precedence.",
@@ -163,6 +164,7 @@ func notionPageMarkdownUpdateSpec() adapter.OperationSpec {
 			Optional: []string{"update_content", "replace_content", "insert_content", "replace_content_range"},
 			Notes: []string{
 				"`type` selects which command payload is required.",
+				"Inline page and database mentions must use `<mention-page>` and `<mention-database>`; standalone `<page>` and `<database>` tags are block references and must stay on their own line.",
 			},
 			Sample: map[string]any{
 				"page_id": "page_demo",

--- a/internal/adapter/notion/payload_validation_test.go
+++ b/internal/adapter/notion/payload_validation_test.go
@@ -428,6 +428,55 @@ func TestBuildUpdatePageMarkdownPayloadRejectsUnsupportedTopLevelFields(t *testi
 	}
 }
 
+func TestBuildUpdatePageMarkdownPayloadRejectsInlinePageAndDatabaseReferenceTags(t *testing.T) {
+	_, appErr := buildUpdatePageMarkdownPayload(map[string]any{
+		"type": "replace_content",
+		"replace_content": map[string]any{
+			"new_str": "- 共享入口页：<page url=\"https://www.notion.so/34734e09734f8198914add9bf199494c\">共享增长资产索引</page>\n- 数据库：<database url=\"https://www.notion.so/dd486be033c5403fbe1ba3de6dc0f9c3\">共享产品库</database>",
+		},
+	})
+	if appErr == nil {
+		t.Fatal("expected buildUpdatePageMarkdownPayload to reject inline page/database references")
+	}
+	if appErr.Code != "INVALID_INPUT" {
+		t.Fatalf("unexpected error code: %s", appErr.Code)
+	}
+	if !strings.Contains(appErr.Message, "<mention-page>/<mention-database>") {
+		t.Fatalf("unexpected error message: %s", appErr.Message)
+	}
+}
+
+func TestBuildUpdatePageMarkdownPayloadAllowsStandaloneReferenceBlocksAndInlineMentions(t *testing.T) {
+	payload, appErr := buildUpdatePageMarkdownPayload(map[string]any{
+		"type": "replace_content",
+		"replace_content": map[string]any{
+			"new_str": "<page url=\"https://www.notion.so/34734e09734f8198914add9bf199494c\">共享增长资产索引</page>\n\n请改为维护 <mention-database url=\"https://www.notion.so/dd486be033c5403fbe1ba3de6dc0f9c3\">共享产品库</mention-database>。",
+		},
+	})
+	if appErr != nil {
+		t.Fatalf("buildUpdatePageMarkdownPayload returned error: %+v", appErr)
+	}
+	if payload["type"] != "replace_content" {
+		t.Fatalf("unexpected payload type: %+v", payload)
+	}
+}
+
+func TestBuildCreatePagePayloadRejectsInlinePageReferenceTagsInMarkdown(t *testing.T) {
+	_, appErr := buildCreatePagePayload(testStaticProfile(), map[string]any{
+		"parent": map[string]any{
+			"type": "page_id",
+			"id":   "page_demo",
+		},
+		"markdown": "请改为维护 <page url=\"https://www.notion.so/34734e09734f8198914add9bf199494c\">共享增长资产索引</page>。",
+	})
+	if appErr == nil {
+		t.Fatal("expected buildCreatePagePayload to reject inline page references in markdown")
+	}
+	if appErr.Code != "INVALID_INPUT" {
+		t.Fatalf("unexpected error code: %s", appErr.Code)
+	}
+}
+
 func TestBuildCreateCommentPayloadValidatesParentsAndAttachments(t *testing.T) {
 	// 评论接口要求 parent 互斥，这里把有效负载与错误路径一起补上。
 	// The comments API requires mutually exclusive parent selectors, so this test covers both one valid payload and the conflicting-input error path.

--- a/skills/clawrise-notion/references/common-tasks.md
+++ b/skills/clawrise-notion/references/common-tasks.md
@@ -128,6 +128,8 @@ Notes:
 - when both input shapes are present on the same block, top-level fields win
 - keep `--dry-run` in the loop until the payload shape is stable
 - add `--verify` on `notion.block.append` or `notion.block.update` when you need immediate read-after-write confirmation
+- do not treat `child_page` blocks as disposable navigation-only items; `notion.block.delete` can archive/trash the underlying page unless you intentionally opt in with `allow_child_page_delete=true`
+- if your Notion integration lacks read content capability, the adapter cannot inspect block type before delete and will still require `allow_child_page_delete=true`
 - add `--debug-provider-payload` on `notion.block.append` or `notion.block.update` when you need to inspect the final provider request and response
 - use `notion.block.get_descendants` instead of repeated `notion.block.list_children` calls when you need the full subtree
 

--- a/skills/clawrise-notion/references/operation-map.md
+++ b/skills/clawrise-notion/references/operation-map.md
@@ -35,7 +35,7 @@ Use this reference when the user describes a Notion task but does not know the e
 - `notion.block.get_descendants`: recursively collect all descendant blocks
 - `notion.block.append`: append child blocks under one block
 - `notion.block.update`: update one block body
-- `notion.block.delete`: archive one block
+- `notion.block.delete`: archive one block (`child_page` targets can archive the underlying page; use with care)
 
 ## File Uploads And Attachments
 


### PR DESCRIPTION
## Summary

This PR adds two Notion safety guards to reduce destructive or silently corrupting write behavior:

- `notion.block.delete` now blocks `child_page` targets by default and requires explicit `allow_child_page_delete=true`
- markdown write paths now reject inline `<page>` / `<database>` tags and direct callers to `<mention-page>` / `<mention-database>` for inline mentions
- tests and docs were updated so runtime behavior and operator guidance stay aligned

## Related Issues

- Closes #13
- Closes #23

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Test only

## Validation

- [x] `go test ./...`
- [x] `go build ./...`
- [ ] Manual CLI verification

List key commands or checks you ran:

```bash
go test ./internal/adapter/notion -run 'TestDeleteBlock(Success|ChildPageRequiresOverride|ChildPageAllowedWithOverride|RequiresOverrideWhenGuardCannotInspectType)$'
go test ./internal/adapter/notion -run 'TestBuild(UpdatePageMarkdownPayload(SupportsReplaceAndRangeCommands|RejectsUnsupportedTopLevelFields|RejectsInlinePageAndDatabaseReferenceTags|AllowsStandaloneReferenceBlocksAndInlineMentions)|CreatePagePayload(RejectsInlinePageReferenceTagsInMarkdown|SupportsMarkdownTemplateAndPosition))$'
go build ./...
go vet ./...
go test ./...
```

## Notes for Reviewers

- The `child_page` delete change is intentionally safety-first: when read capability is missing, delete now requires explicit opt-in rather than proceeding blindly.
- The markdown mention change is a guardrail, not a local markdown renderer fix. It prevents a known bad input shape from being sent upstream and documents the Notion enhanced markdown distinction between block references and inline mentions.
- No live Notion workspace verification was run in this branch.

## Checklist

- [x] I updated docs when behavior changed.
- [x] I sanitized logs, payloads, and examples.
- [x] I kept the pull request focused and reviewable.
