### PR TITLE
Improve CLI help and onboarding guidance for auth and automation

### DIFF
--- a/docs/en/ai-install.md
+++ b/docs/en/ai-install.md
@@ -62,10 +62,9 @@ Setup is responsible for:
 - installing any requested platform skills
 - configuring default platform accounts when credentials are available
 
-Default setup account names:
+Setup-generated default account names come from the selected auth preset metadata and may vary by platform and auth method.
 
-- `notion_bot`
-- `feishu_bot`
+Do not hard-code account names in automation unless you passed `--account` explicitly during setup.
 
 If no platform is specified, setup installs only `clawrise-core` and does not initialize a platform account.
 
@@ -93,6 +92,10 @@ FEISHU_APP_ID=cli_xxx FEISHU_APP_SECRET=cli_secret_xxx clawrise setup codex feis
 ```
 
 If the environment variables are missing and the shell is interactive, `setup` can prompt for the required credentials directly.
+
+Environment variables are only an import source during setup.
+
+After setup imports the credentials, Clawrise persists them in its configured secret store for normal execution. Long-lived automation should not rely on recurring shell rc injection such as `~/.bashrc`.
 
 Client-specific examples:
 
@@ -128,11 +131,18 @@ clawrise doctor
 clawrise spec list
 ```
 
-If platform setup was requested, also verify the default account:
+If platform setup was requested, first verify the current default selection:
 
 ```bash
-clawrise auth check notion_bot
-clawrise auth check feishu_bot
+clawrise auth check
+```
+
+If you need the explicit generated account name, inspect it before hard-coding follow-up commands:
+
+```bash
+clawrise account list
+clawrise auth presets --platform notion
+clawrise auth presets --platform feishu
 ```
 
 Also verify that the installed skill directories exist in the target location.
@@ -148,6 +158,12 @@ Expected skill names:
 If installation fails because of write permissions:
 
 - switch from a shared install path to a project-local install path
+
+If you later import secrets outside of `setup`:
+
+- treat `clawrise auth secret set ...` as a one-time import into the configured secret store
+- prefer `--stdin`, a real process environment with `--from-env`, or direct provisioning into the secret backend
+- avoid relying on non-interactive shell startup files for recurring secret injection
 
 If the user only wants one platform skill:
 

--- a/docs/en/auth-model.md
+++ b/docs/en/auth-model.md
@@ -34,6 +34,8 @@ Examples:
 - `feishu_user_alice`
 - `notion_bot`
 
+These example account names are illustrative only. Setup-generated default account names come from preset metadata and may differ by platform or auth method.
+
 ### Subject
 
 Subject describes the identity category used at the provider side.

--- a/docs/zh/ai-install.md
+++ b/docs/zh/ai-install.md
@@ -70,10 +70,9 @@ npx @clawrise/clawrise-cli setup ...
 - 安装请求的平台 skills
 - 在凭证可用时初始化默认平台账号
 
-默认 setup 账号名：
+setup 生成的默认账号名来自所选 auth preset 的元数据，不同平台和鉴权方式可能不同。
 
-- `notion_bot`
-- `feishu_bot`
+除非你在 setup 时显式传了 `--account`，否则不要在自动化里硬编码账号名。
 
 如果没有指定平台，`setup` 只安装 `clawrise-core`，不会初始化平台账号。
 
@@ -101,6 +100,10 @@ FEISHU_APP_ID=cli_xxx FEISHU_APP_SECRET=cli_secret_xxx clawrise setup codex feis
 ```
 
 如果缺少环境变量且当前 shell 可交互，`setup` 会直接提示输入所需凭证。
+
+环境变量在这里只是导入来源。
+
+setup 导入凭证后，Clawrise 会把它们持久化到配置好的 secret store 中供后续正常执行使用。长期自动化不应依赖反复从 `~/.bashrc` 之类的 shell rc 文件注入。
 
 按客户端区分的示例：
 
@@ -136,11 +139,18 @@ clawrise doctor
 clawrise spec list
 ```
 
-如果 setup 里包含平台初始化，再校验默认账号：
+如果 setup 里包含平台初始化，先验证当前默认选择：
 
 ```bash
-clawrise auth check notion_bot
-clawrise auth check feishu_bot
+clawrise auth check
+```
+
+如果你确实需要拿到 setup 生成的显式账号名，再先查看后续要引用的名字：
+
+```bash
+clawrise account list
+clawrise auth presets --platform notion
+clawrise auth presets --platform feishu
 ```
 
 同时确认目标目录中已出现这些 skill：
@@ -154,6 +164,12 @@ clawrise auth check feishu_bot
 如果安装失败是因为写权限不足：
 
 - 改为安装到项目内 skills 目录
+
+如果你在 `setup` 之外单独导入 secret：
+
+- 把 `clawrise auth secret set ...` 理解成一次性导入到 secret store
+- 优先使用 `--stdin`、真实进程环境里的 `--from-env`，或直接写入所配置的 secret backend
+- 避免依赖非交互 shell 的启动文件来反复注入 secret
 
 如果用户只需要一个平台：
 

--- a/docs/zh/auth-model.md
+++ b/docs/zh/auth-model.md
@@ -34,6 +34,8 @@ Account 是用户显式选择或默认选中的具体执行身份。
 - `feishu_user_alice`
 - `notion_bot`
 
+这些账号名只是示例。setup 自动生成的默认账号名来自 preset 元数据，会因平台或鉴权方式不同而变化。
+
 ### Subject
 
 Subject 表示请求在平台侧归属于哪类主体。

--- a/internal/cli/auth.go
+++ b/internal/cli/auth.go
@@ -84,11 +84,16 @@ func runAuthInspect(args []string, cfg *config.Config, store *config.Store, stdo
 	if manager == nil {
 		return fmt.Errorf("plugin manager is required")
 	}
-	if len(args) > 1 {
-		return fmt.Errorf("usage: clawrise auth inspect [account]")
+
+	parsedArgs, handled, err := parseAuthOptionalAccountArgs("inspect", args, stdout)
+	if err != nil {
+		return err
+	}
+	if handled {
+		return nil
 	}
 
-	accountName, account, ok, err := resolveAccountSelection(cfg, args)
+	accountName, account, ok, err := resolveAccountSelection(cfg, parsedArgs)
 	if err != nil {
 		return writeCLIError(stdout, "ACCOUNT_REQUIRED", err.Error())
 	}
@@ -113,10 +118,17 @@ func runAuthInspect(args []string, cfg *config.Config, store *config.Store, stdo
 }
 
 func runAuthCheck(args []string, cfg *config.Config, store *config.Store, stdout io.Writer, manager *pluginruntime.Manager) error {
-	if err := runAuthInspect(args, cfg, store, stdout, manager); err != nil {
+	parsedArgs, handled, err := parseAuthOptionalAccountArgs("check", args, stdout)
+	if err != nil {
 		return err
 	}
-	accountName, account, ok, err := resolveAccountSelection(cfg, args)
+	if handled {
+		return nil
+	}
+	if err := runAuthInspect(parsedArgs, cfg, store, stdout, manager); err != nil {
+		return err
+	}
+	accountName, account, ok, err := resolveAccountSelection(cfg, parsedArgs)
 	if err != nil {
 		return err
 	}
@@ -366,11 +378,15 @@ func runAuthComplete(args []string, cfg *config.Config, store *config.Store, std
 }
 
 func runAuthLogout(args []string, cfg *config.Config, store *config.Store, stdout io.Writer) error {
-	if len(args) > 1 {
-		return fmt.Errorf("usage: clawrise auth logout [account]")
+	parsedArgs, handled, err := parseAuthOptionalAccountArgs("logout", args, stdout)
+	if err != nil {
+		return err
+	}
+	if handled {
+		return nil
 	}
 
-	accountName, account, ok, err := resolveAccountSelection(cfg, args)
+	accountName, account, ok, err := resolveAccountSelection(cfg, parsedArgs)
 	if err != nil {
 		return writeCLIError(stdout, "ACCOUNT_REQUIRED", err.Error())
 	}
@@ -405,6 +421,28 @@ func runAuthLogout(args []string, cfg *config.Config, store *config.Store, stdou
 			"logged_out": true,
 		},
 	})
+}
+
+func parseAuthOptionalAccountArgs(command string, args []string, stdout io.Writer) ([]string, bool, error) {
+	flags := pflag.NewFlagSet("clawrise auth "+command, pflag.ContinueOnError)
+	flags.SetOutput(stdout)
+	flags.Usage = func() {
+		_, _ = fmt.Fprintf(stdout, "Usage: clawrise auth %s [account]\n", command)
+		_, _ = fmt.Fprintln(stdout, "")
+		_, _ = fmt.Fprintln(stdout, "If account is omitted, Clawrise uses the current/default account selection.")
+		_, _ = fmt.Fprintln(stdout, "  -h, --help   show this help message")
+	}
+
+	if err := flags.Parse(args); err != nil {
+		if err == pflag.ErrHelp {
+			return nil, true, nil
+		}
+		return nil, false, err
+	}
+	if len(flags.Args()) > 1 {
+		return nil, false, fmt.Errorf("usage: clawrise auth %s [account]", command)
+	}
+	return flags.Args(), false, nil
 }
 
 func resolveAccountSelection(cfg *config.Config, args []string) (string, config.Account, bool, error) {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -768,6 +768,7 @@ func printRootHelp(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "Write Enhancements:")
 	_, _ = fmt.Fprintln(w, "  --verify                  read back and verify the result after a successful write when supported")
 	_, _ = fmt.Fprintln(w, "  --debug-provider-payload  include the final provider request and response payloads when supported")
+	_, _ = fmt.Fprintln(w, "  For automation and non-trivial payloads, prefer --input <path> or stdin over shell-quoted --json.")
 	_, _ = fmt.Fprintln(w, "")
 	_, _ = fmt.Fprintln(w, "Examples:")
 	_, _ = fmt.Fprintln(w, "  clawrise notion.block.append --dry-run --json '{\"block_id\":\"blk_demo\",\"children\":[{\"type\":\"paragraph\",\"text\":\"Hello Clawrise\"}]}'")

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -1892,6 +1892,33 @@ func TestRunAuthCheck(t *testing.T) {
 	}
 }
 
+func TestRunAuthCheckHelpFlag(t *testing.T) {
+	copyExampleConfig(t)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	err := Run([]string{"auth", "check", "--help"}, Dependencies{
+		Version:       "test",
+		Stdout:        &stdout,
+		Stderr:        &stderr,
+		PluginManager: newTestPluginManager(t),
+	})
+	if err != nil {
+		t.Fatalf("Run returned error: %v, stdout=%s, stderr=%s", err, stdout.String(), stderr.String())
+	}
+
+	if !bytes.Contains(stdout.Bytes(), []byte("Usage: clawrise auth check [account]")) {
+		t.Fatalf("expected auth check help output, got: %s", stdout.String())
+	}
+	if bytes.Contains(stdout.Bytes(), []byte(`"code": "ACCOUNT_NOT_FOUND"`)) {
+		t.Fatalf("did not expect auth check help to be treated as an account lookup: %s", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected empty stderr, got: %s", stderr.String())
+	}
+}
+
 func TestRunAuthCheckReportsAuthorizationPending(t *testing.T) {
 	copyExampleConfig(t)
 	runSecretSet(t, "notion_public_workspace_a", "client_secret", "client-secret")

--- a/internal/runtime/input.go
+++ b/internal/runtime/input.go
@@ -14,14 +14,14 @@ func ReadInput(jsonText, inputPath string, stdin io.Reader) (map[string]any, err
 	case strings.TrimSpace(jsonText) != "" && strings.TrimSpace(inputPath) != "":
 		return nil, fmt.Errorf("cannot use --json and --input at the same time")
 	case strings.TrimSpace(jsonText) != "":
-		return decodeJSON(strings.NewReader(jsonText))
+		return decodeJSON(strings.NewReader(jsonText), "--json")
 	case strings.TrimSpace(inputPath) != "":
 		path := strings.TrimSpace(strings.TrimPrefix(inputPath, "@"))
 		data, err := os.ReadFile(path)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read input file: %w", err)
 		}
-		return decodeJSON(strings.NewReader(string(data)))
+		return decodeJSON(strings.NewReader(string(data)), "--input")
 	case stdin != nil:
 		data, err := io.ReadAll(stdin)
 		if err != nil {
@@ -30,18 +30,22 @@ func ReadInput(jsonText, inputPath string, stdin io.Reader) (map[string]any, err
 		if strings.TrimSpace(string(data)) == "" {
 			return map[string]any{}, nil
 		}
-		return decodeJSON(strings.NewReader(string(data)))
+		return decodeJSON(strings.NewReader(string(data)), "stdin")
 	default:
 		return map[string]any{}, nil
 	}
 }
 
-func decodeJSON(reader io.Reader) (map[string]any, error) {
+func decodeJSON(reader io.Reader, source string) (map[string]any, error) {
 	var input map[string]any
 	decoder := json.NewDecoder(reader)
 	decoder.UseNumber()
 	if err := decoder.Decode(&input); err != nil {
-		return nil, fmt.Errorf("failed to decode JSON input: %w", err)
+		message := fmt.Sprintf("failed to decode JSON input from %s: %v", source, err)
+		if source == "--json" {
+			message += "; check shell quoting/escaping or prefer --input <file> for automation"
+		}
+		return nil, fmt.Errorf("%s", message)
 	}
 	if input == nil {
 		return map[string]any{}, nil

--- a/internal/runtime/input_helpers_test.go
+++ b/internal/runtime/input_helpers_test.go
@@ -74,6 +74,23 @@ func TestReadInputCoversInlineFileAndStdinPaths(t *testing.T) {
 		if err == nil || !strings.Contains(err.Error(), "failed to decode JSON input") {
 			t.Fatalf("expected json decode failure, got: %v", err)
 		}
+		if !strings.Contains(err.Error(), "prefer --input <file> for automation") {
+			t.Fatalf("expected inline json guidance in decode failure, got: %v", err)
+		}
+	})
+
+	t.Run("keeps file decode failures source-specific without shell quoting hint", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "broken.json")
+		if err := os.WriteFile(path, []byte("{"), 0o600); err != nil {
+			t.Fatalf("failed to write broken input file: %v", err)
+		}
+		_, err := ReadInput("", path, nil)
+		if err == nil || !strings.Contains(err.Error(), "failed to decode JSON input from --input") {
+			t.Fatalf("expected file decode failure, got: %v", err)
+		}
+		if strings.Contains(err.Error(), "prefer --input <file> for automation") {
+			t.Fatalf("did not expect shell quoting hint for file input, got: %v", err)
+		}
 	})
 
 	t.Run("returns empty map for null json", func(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR fixes several CLI/onboarding issues without deepening coupling between the core CLI and specific provider plugins:

- `clawrise auth check --help` now shows command help instead of treating `--help` as an account name
- root/runtime guidance now steers automation users toward `--input <file>` when `--json` fails due to shell quoting
- AI install and auth model docs no longer hard-code setup-generated account names and now explain how to inspect the actual generated account
- onboarding docs now explain that environment variables are import sources, while secrets are persisted in Clawrise's configured secret store for ongoing use

## Related Issues

- Closes #6
- Closes #7
- Closes #8
- Closes #9

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Test only

## Validation

- [x] `go test ./...`
- [x] `go build ./...`
- [ ] Manual CLI verification

List key commands or checks you ran:

```bash
go test ./internal/cli -run 'TestRun(AuthCheck|AuthCheckHelpFlag|AuthCheckReportsAuthorizationPending|AuthMethodsAndPresets)$'
go test ./internal/runtime -run 'TestReadInputCoversInlineFileAndStdinPaths$'
go build ./...
go vet ./...
go test ./...
```

## Notes for Reviewers

- The fixes intentionally stay at the shared CLI/runtime/docs boundary so Clawrise does not become more tightly coupled to Notion/Feishu-specific account naming or UX branches.
- The docs now treat setup-generated account names as preset metadata rather than stable provider-specific constants.
- No fresh npm-installed manual verification was run in this branch.

## Checklist

- [x] I updated docs when behavior changed.
- [x] I sanitized logs, payloads, and examples.
- [x] I kept the pull request focused and reviewable.
