### PR TITLE
Make --verify fail fast when an operation does not support it

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -766,7 +766,7 @@ func printRootHelp(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "  clawrise version")
 	_, _ = fmt.Fprintln(w, "")
 	_, _ = fmt.Fprintln(w, "Write Enhancements:")
-	_, _ = fmt.Fprintln(w, "  --verify                  read back and verify the result after a successful write when supported")
+	_, _ = fmt.Fprintln(w, "  --verify                  read back and verify the result after a successful write when supported; unsupported uses fail fast")
 	_, _ = fmt.Fprintln(w, "  --debug-provider-payload  include the final provider request and response payloads when supported")
 	_, _ = fmt.Fprintln(w, "  For automation and non-trivial payloads, prefer --input <path> or stdin over shell-quoted --json.")
 	_, _ = fmt.Fprintln(w, "")

--- a/internal/runtime/executor.go
+++ b/internal/runtime/executor.go
@@ -120,6 +120,10 @@ func (e *Executor) Execute(ctx context.Context, opts ExecuteOptions) (Envelope, 
 		return e.auditEnvelope(governance, e.finish(startAt, requestID, canonicalOperation, operation.Platform, opts.DryRun, nil, nil, 0, apperr.New("SUBJECT_NOT_ALLOWED", fmt.Sprintf("account %s with subject %s is not allowed to call %s", accountName, account.Subject, canonicalOperation)), ExecutionProfile{}), input), nil
 	}
 
+	if appErr := validateWriteEnhancements(canonicalOperation, definition, opts); appErr != nil {
+		return e.auditEnvelope(governance, e.finish(startAt, requestID, canonicalOperation, operation.Platform, opts.DryRun, nil, nil, 0, appErr, ExecutionProfile{}), input), nil
+	}
+
 	warnings = append(warnings, writeEnhancementWarnings(canonicalOperation, opts)...)
 
 	executionProfile := ExecutionProfile{
@@ -508,6 +512,16 @@ func writeEnhancementWarnings(operation string, opts ExecuteOptions) []string {
 		}
 	}
 	return warnings
+}
+
+func validateWriteEnhancements(operation string, definition adapter.Definition, opts ExecuteOptions) *apperr.AppError {
+	if !opts.VerifyAfterWrite || opts.DryRun || !definition.Mutating {
+		return nil
+	}
+	if supportsWriteVerification(operation) {
+		return nil
+	}
+	return apperr.New("UNSUPPORTED_WRITE_ENHANCEMENT", "--verify is not supported for "+operation)
 }
 
 func supportsProviderPayloadDebug(operation string) bool {

--- a/internal/runtime/executor_test.go
+++ b/internal/runtime/executor_test.go
@@ -857,6 +857,64 @@ func TestExecutorExecutesNotionPageMarkdownGet(t *testing.T) {
 	}
 }
 
+func TestExecutorRejectsUnsupportedVerifyForNotionPageMarkdownUpdate(t *testing.T) {
+	t.Setenv("NOTION_ACCESS_TOKEN", "notion-token")
+
+	store := newTestStore(t, &config.Config{
+		Defaults: config.Defaults{
+			Platform: "notion",
+			Account:  "notion_team_docs",
+		},
+		Accounts: accountsFromLegacyAccounts(map[string]legacyTestAccount{
+			"notion_team_docs": {
+				Platform: "notion",
+				Subject:  "integration",
+				LegacyAuth: legacyTestAuth{
+					Type:  "static_token",
+					Token: "env:NOTION_ACCESS_TOKEN",
+				},
+			},
+		}),
+	})
+
+	notionClient, err := notionadapter.NewClient(notionadapter.Options{
+		BaseURL: "https://api.notion.com",
+		HTTPClient: &http.Client{
+			Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+				t.Fatalf("unexpected provider request for unsupported verify path: %s %s", request.Method, request.URL.Path)
+				return nil, nil
+			}),
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to construct notion client: %v", err)
+	}
+
+	executor := &Executor{
+		store:    store,
+		registry: newTestRegistry(t, nil, notionClient),
+		now:      time.Now,
+	}
+
+	envelope, err := executor.ExecuteContext(context.Background(), ExecuteOptions{
+		OperationInput:   "page.markdown.update",
+		VerifyAfterWrite: true,
+		InputJSON:        `{"page_id":"page_demo","type":"replace_content","replace_content":{"new_str":"# Updated title"}}`,
+	})
+	if err != nil {
+		t.Fatalf("ExecuteContext returned error: %v", err)
+	}
+	if envelope.OK {
+		t.Fatalf("expected unsupported verify execution to fail, got data: %+v", envelope.Data)
+	}
+	if envelope.Error == nil || envelope.Error.Code != "UNSUPPORTED_WRITE_ENHANCEMENT" {
+		t.Fatalf("unexpected error payload: %+v", envelope.Error)
+	}
+	if !strings.Contains(envelope.Error.Message, "--verify is not supported for notion.page.markdown.update") {
+		t.Fatalf("unexpected error message: %+v", envelope.Error)
+	}
+}
+
 func TestExecutorExecutesNotionSearch(t *testing.T) {
 	t.Setenv("NOTION_ACCESS_TOKEN", "notion-token")
 

--- a/internal/runtime/helpers_more_test.go
+++ b/internal/runtime/helpers_more_test.go
@@ -86,6 +86,12 @@ func TestExecutorHelperFunctionsAndAccountSelection(t *testing.T) {
 	if !supportsWriteVerification("notion.block.update") || supportsWriteVerification("notion.database.query") {
 		t.Fatal("unexpected supportsWriteVerification behavior")
 	}
+	if appErr := validateWriteEnhancements("notion.page.markdown.update", adapter.Definition{Mutating: true}, ExecuteOptions{VerifyAfterWrite: true}); appErr == nil || appErr.Code != "UNSUPPORTED_WRITE_ENHANCEMENT" {
+		t.Fatalf("expected strict unsupported verify error, got %+v", appErr)
+	}
+	if appErr := validateWriteEnhancements("notion.page.markdown.update", adapter.Definition{Mutating: true}, ExecuteOptions{VerifyAfterWrite: true, DryRun: true}); appErr != nil {
+		t.Fatalf("expected dry-run verify to stay warning-only, got %+v", appErr)
+	}
 	warnings := writeEnhancementWarnings("feishu.doc.create", ExecuteOptions{DebugProviderPayload: true, VerifyAfterWrite: true})
 	if len(warnings) != 2 {
 		t.Fatalf("expected unsupported enhancement warnings, got %+v", warnings)


### PR DESCRIPTION
## Summary

This PR changes `--verify` from a warning-only soft hint into a strict runtime contract for non-dry-run writes:

- unsupported `--verify` requests now fail fast before executing the write
- dry-run behavior remains warning-only because no write is executed in that path
- root help text now makes the strict contract explicit
- regression tests cover the shared runtime behavior and the concrete `notion.page.markdown.update --verify` case

The fix is intentionally implemented in the shared runtime layer, not as a Notion-specific special case.

## Related Issues

- Closes #22
- Closes #21

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Test only

## Validation

- [x] `go test ./...`
- [x] `go build ./...`
- [ ] Manual CLI verification

List key commands or checks you ran:

```bash
go test ./internal/runtime -run 'Test(ExecutorHelperFunctionsAndAccountSelection|ExecutorRejectsUnsupportedVerifyForNotionPageMarkdownUpdate|ExecutorExecutesNotionPageMarkdownGet)$'
go build ./...
go vet ./...
go test ./...
```

## Notes for Reviewers

- This PR fixes the systemic contract problem in runtime/core rather than adding another provider-specific verification branch for Notion.
- Unsupported non-dry-run `--verify` now returns `UNSUPPORTED_WRITE_ENHANCEMENT` and stops before the provider write executes.
- Dry-run still surfaces warning-only behavior for write enhancements because no mutation is attempted there.
- No live provider verification was run in this branch.

## Checklist

- [x] I updated docs when behavior changed.
- [x] I sanitized logs, payloads, and examples.
- [x] I kept the pull request focused and reviewable.
